### PR TITLE
Migrate to namespaced PHPUnit

### DIFF
--- a/GoogleGeocodeService.php
+++ b/GoogleGeocodeService.php
@@ -114,7 +114,7 @@ class GoogleGeocodeService
         }
 
         if ($sortByDistance) {
-            usort($routes, function(Route $a, Route $b) {
+            usort($routes, function (Route $a, Route $b) {
                 return $a->compareTo($b);
             });
         }

--- a/Tests/PointTest.php
+++ b/Tests/PointTest.php
@@ -18,16 +18,16 @@ use Gibilogic\Elements\Geocoding\Point;
  *
  * @author Matteo Guindani https://github.com/Ingannatore
  * @see Point
- * @see \PHPUnit_Framework_TestCase
+ * @see \PHPUnit\Framework\TestCase
  */
-class PointTest extends \PHPUnit_Framework_TestCase
+class PointTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests for invalid latitude values during class construction.
      */
     public function testInvalidLatitude()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         new Point(91, 0);
     }
 
@@ -36,7 +36,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidLongitude()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         new Point(0, 181);
     }
 

--- a/Tests/RouteTest.php
+++ b/Tests/RouteTest.php
@@ -19,9 +19,9 @@ use Gibilogic\Elements\Geocoding\Route;
  *
  * @author Matteo Guindani https://github.com/Ingannatore
  * @see Route
- * @see \PHPUnit_Framework_TestCase
+ * @see \PHPUnit\Framework\TestCase
  */
-class RouteTest extends \PHPUnit_Framework_TestCase
+class RouteTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests the calculation of distance between points.

--- a/composer.json
+++ b/composer.json
@@ -3,16 +3,23 @@
     "type": "library",
     "description": "GiBiLogic Elements - Geocoding",
     "keywords": [],
-    "homepage": "http://www.gibilogic.com",
+    "homepage": "https://gibilogic.com",
     "license": "MIT",
     "authors": [
         {
             "name":     "GiBilogic Srl",
-            "homepage": "http://www.gibilogic.com",
+            "homepage": "https://gibilogic.com",
             "email":    "info@gibilogic.com"
         }
     ],
-    "require": {},
+    "require": {
+        "php": ">=5.5",
+        "ext-curl": "*",
+        "ext-json": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.0"
+    },
     "autoload": {
         "psr-4": { "Gibilogic\\Elements\\Geocoding\\": "" }
     }

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.6",
         "ext-curl": "*",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0"
+        "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": { "Gibilogic\\Elements\\Geocoding\\": "" }


### PR DESCRIPTION
This PR follow (and include) PR #2.

Migrate current tests to namespaced PHPUnit, introducing support for versions from 5 to 8, dropping support for PHP 5.5 (EOL 21 Jul 2016, over 7 years ago) and PHPUnit 4.8 (EOL 3 February 2017, over 6 years ago).

New requirements are PHP 5.6+ and PHPUnit 5.x - 8.x.
